### PR TITLE
PHP 7 and increasing min PHP to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: php
 php:
   - 5.5
   - 5.6
-#  - 7.0
-#  - hhvm
+  - 7.0
+  - 7.1
 
 env: COVERAGE=0
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: COVERAGE=1
 
 before_script:

--- a/Tests/Twig/Extension/OneHydraExtensionTest.php
+++ b/Tests/Twig/Extension/OneHydraExtensionTest.php
@@ -40,7 +40,7 @@ class OneHydraExtensionTest extends PHPUnit_Framework_TestCase
         $twig->addExtension($extension);
 
         /** @var OneHydraExtension $ext */
-        $ext = $twig->getExtension('onehydra_extension');
+        $ext = $twig->getExtension(OneHydraExtension::class);
 
         $this->assertInstanceOf(OneHydraExtension::class, $ext);
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.9",
+    "php": ">=5.5.0,<8.0",
     "amara/onehydra": "~0.2.0",
     "symfony/framework-bundle": "~2.3|~3.0",
     "doctrine/orm": "~2.2,>=2.2.3,<2.5",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">=5.5.0,<8.0",
-    "amara/onehydra": "~0.2.0",
+    "amara/onehydra": "~0.3.0",
     "symfony/framework-bundle": "~2.3|~3.0",
     "doctrine/orm": "~2.2,>=2.2.3,<2.5",
     "doctrine/doctrine-bundle": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/framework-bundle": "~2.3|~3.0",
     "doctrine/orm": "~2.2,>=2.2.3,<2.5",
     "doctrine/doctrine-bundle": "~1.4",
-    "twig/twig": "~1.23|~2.0"
+    "twig/twig": "~1.26|~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
* Increased max PHP version to 7
* Increased min PHP version to 5.5 (the php-onehydra library also required PHP 5.5, so it's not a BC break really)
* Increased min Twig requirement to 1.26